### PR TITLE
feat: Add a function to get data from GeoNames API

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,8 @@
-{ 'presets': ['@babel/preset-env']}
+{
+    "presets": ["@babel/preset-env"],
+    "env": {
+        "test": {
+            "plugins": ["@babel/plugin-transform-runtime"]
+        }
+    }
+}

--- a/__test__/getCoordinatesFromApi.test.js
+++ b/__test__/getCoordinatesFromApi.test.js
@@ -1,0 +1,14 @@
+import { getCoordinatesFromApi } from "../src/client/js/callGeonamesApi"
+
+describe("Testing the value returned from API", () => {
+    // The test() function has two arguments - a string description, and an actual test as a callback function.  
+    test("Testing the getCoordinatesFromApi() function", () => {
+
+        // Define the input for the function, if any, in the form of variables/array
+        const baseUrl = 'http://api.geonames.org/searchJSON?q=';
+        const place = 'london';
+        const apiKey = 'janainamj';
+
+        expect(getCoordinatesFromApi(baseUrl, place, apiKey)).toBeDefined();
+    }) 
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -931,6 +931,20 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.3.tgz",
+      "integrity": "sha512-t960xbi8wpTFE623ef7sd+UpEC5T6EEguQlTBJDEO05+XwnIWVfuqLw/vdLWY6IdFmtZE+65CZAfByT39zRpkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "babel-plugin-polyfill-corejs2": "^0.2.0",
+        "babel-plugin-polyfill-corejs3": "^0.2.0",
+        "babel-plugin-polyfill-regenerator": "^0.2.0",
+        "semver": "^6.3.0"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
+    "@babel/plugin-transform-runtime": "^7.14.3",
     "@babel/preset-env": "^7.14.4",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "^4.0.0-alpha.0",

--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -1,5 +1,10 @@
 //Importing helper functions
 import { encodeUrl } from './urlEncoder'
+import { getCoordinatesFromApi } from './callGeonamesApi'
+
+//* APIs keys *//
+const geoNamesBaseURL = 'http://api.geonames.org/searchJSON?q='
+const geoNamesKey = 'janainamj'
 
 //Wrapping functionalities in a init() function to be executed only after DOM is ready
 function init(){
@@ -15,6 +20,10 @@ function init(){
         const travelDate = document.getElementById('date').value;
         let placeName = document.getElementById('place').value;
         const placeEncoded = encodeUrl(placeName); //encoding user entries to use in a url
+
+        //Using user inputs to call geoNames API and get Latitude and Longitude parameters
+        getCoordinatesFromApi(geoNamesBaseURL, placeEncoded, geoNamesKey)
+
     }
 }
 

--- a/src/client/js/callGeonamesApi.js
+++ b/src/client/js/callGeonamesApi.js
@@ -1,0 +1,20 @@
+//GET request to 'GEONAMES' API
+const getCoordinatesFromApi = async(baseUrl, place, apiKey)=>{
+
+    const res = await fetch(baseUrl + place + "&maxRows=10&username=" + apiKey)
+
+    try{
+        const apiData = await res.json();
+        const data = {
+            latitude: apiData.geonames[0].lat,
+            longitude: apiData.geonames[0].lng,
+            country: apiData.geonames[0].countryName
+        }
+        console.log('API object received by the GeoNames function', apiData);
+        return data;
+    }catch(error){
+        console.log('Error getting object from API', error);
+    }
+}
+
+export { getCoordinatesFromApi }


### PR DESCRIPTION
This is the first step of a more complex function that will be
developed. The purpose of this call to GeoNames API is to collect the
geographic coordinates related to the location that the user entered in
the form input.
In this regard, it was necessary to include the Babel transform-runtime
plugin to enable Jest tests on functions that make API calls.