### PR TITLE
feat: Create a proxy to allow shared network connections on web requests

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -13,6 +13,12 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(cors());
 
+//Building my own proxy
+app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    next();
+})
+
 //** Main GET route **//
 app.get('/', function (req, res) {
     res.sendFile(path.resolve('dist/index.html'))


### PR DESCRIPTION
This is necessary when working with APIs, to prevent fetch requests
from being blocked by the CORS policy: 'No Access-Control-Allow-Origin
header is present on the requested resource'.