### PR TITLE
feat: Add post route to use url coming from client-side and call APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7614,6 +7614,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "node-fetch": "^2.6.1",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.0"
   },

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ const app = express();
 const bodyParser = require('body-parser');
 const cors = require('cors');
 var path = require('path');
+const fetch = require('node-fetch');
 
 app.use(express.static('dist'));
 app.use(bodyParser.urlencoded({ extended: false }));
@@ -29,6 +30,24 @@ app.get('/all', sendData);
 function sendData(req, res){    
      res.send(projectData);
 }
+
+//** POST route to handle url coming from client side, call the API and send the data to client side **//
+app.post('/callAPI', async (req, res) => {
+
+    const apiUrl = req.body.urlBase;
+    
+    const resp = await fetch(apiUrl)
+
+    try{ //try to send API data to client side
+
+        const data = await resp.json();
+        res.send(data);
+
+    }catch(err) {
+        
+        console.log("error when calling API via server side", err);
+    }
+})
 
 //** Setup Server **//
 const port = 8081;


### PR DESCRIPTION
This route is to handle specific client-side post requests, which
request calls to APIs via server-side.
Related to this, it was necessary to install node-fetch package to
enable the use of fetch() function in NodeJs.