### PR TITLE
refactor: Change the way the app handles trips that are 365 days away

### DIFF
--- a/src/client/js/callGeonamesApi.js
+++ b/src/client/js/callGeonamesApi.js
@@ -8,7 +8,8 @@ const getCoordinatesFromApi = async(baseUrl, place, apiKey)=>{
         const data = {
             latitude: apiData.geonames[0].lat,
             longitude: apiData.geonames[0].lng,
-            country: apiData.geonames[0].countryName
+            country: apiData.geonames[0].countryName,
+            city: apiData.geonames[0].toponymName
         }
         console.log('API object received by the GeoNames function', apiData);
         return data;

--- a/src/client/js/getHistoricWeatherFromTravelDt.js
+++ b/src/client/js/getHistoricWeatherFromTravelDt.js
@@ -1,0 +1,50 @@
+import { callApiViaServerSide } from "./postRequestToServer"
+
+/* The 3 years of historical weather data are being fetched in 3 separate GET requests due to the
+free API registration plan limitation */
+const getHistoricWeatherFromTravelDt = async (obj, apiUrl1, apiUrl2, apiUrl3)=>{
+
+    const respOne = await callApiViaServerSide('http://localhost:8081/callAPI', {urlBase:apiUrl1})
+    const respTwo = await callApiViaServerSide('http://localhost:8081/callAPI', {urlBase:apiUrl2})
+    const respThree = await callApiViaServerSide('http://localhost:8081/callAPI', {urlBase:apiUrl3})
+
+    try{
+
+        const storeDataOne = await respOne;
+
+        obj.oneYearPredictions = {
+            date: storeDataOne.location.values[0].datetimeStr,
+            conditions: storeDataOne.location.values[0].conditions,
+            maxT: storeDataOne.location.values[0].maxt,
+            minT: storeDataOne.location.values[0].mint,
+            precipitation: storeDataOne.location.values[0].precip
+        }
+
+        const storeDataTwo = await respTwo;
+
+        obj.twoYearPredictions = {
+            date: storeDataTwo.location.values[0].datetimeStr,
+            conditions: storeDataTwo.location.values[0].conditions,
+            maxT: storeDataTwo.location.values[0].maxt,
+            minT: storeDataTwo.location.values[0].mint,
+            precipitation: storeDataTwo.location.values[0].precip
+        }
+
+        const storeDataThree = await respThree;
+
+        obj.threeYearPredictions = {
+            date: storeDataThree.location.values[0].datetimeStr,
+            conditions: storeDataThree.location.values[0].conditions,
+            maxT: storeDataThree.location.values[0].maxt,
+            minT: storeDataThree.location.values[0].mint,
+            precipitation: storeDataThree.location.values[0].precip
+        }
+
+        return obj;
+
+    } catch(err){
+        console.log('Erro tentando fazer uma promisse', err);
+    }
+}
+
+export { getHistoricWeatherFromTravelDt }


### PR DESCRIPTION
Changes the way the main function handles trips within 365 days away.
In this way, it'll be possible to make separate calls to historical
weather API when the trip is within 365 days and when the trip is more
than 365 days away.