### PR TITLE
feat: Fetch historical weather for trips that are more than 1 year away

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -5,7 +5,7 @@ import { callApiViaServerSide } from './postRequestToServer'
 import { dayCounter } from './counter'
 import { updateUICurrentWeather } from './updateUICurrentW'
 import { validateForm } from './formValidator'
-import { getHistoricWeatherFromTravelDt } from './getHistoricWeatherFromTravelDt'
+import { getHistoricWeather } from './getHistoricWeather'
 
 //Primary Object to hold data from GeoNames API
 var primaryData = {};
@@ -18,9 +18,26 @@ const weatherBitKey = '723118fb280a46d5bc650aaaa26b3479'
 const visualCrossingBaseURL = 'https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/weatherdata/history?'
 const visualCrossingKey = 'ZQFMC9TG68TNK7BM2YRMJJFE2'
 
-//global variable (helper function)
-const buildHistoricApiURLs = (dt)=>{
+//start - global variable (helper function)
+const buildHistoricApiURLs = (dateInput)=>{
 
+    function setTravelDate(){
+
+        //if the trip is within one year, use the travel date entered by the user to fetch historical weather
+        if(dayCounter(dateInput) > 7 && dayCounter(dateInput) <= 365){
+            return dateInput; //travel date entered by the user
+
+        //if the trip is more than one year away, use a new set date (based on the current year) to fetch historical weather
+        } else{
+            let todayDate = new Date();
+            const currentYear = todayDate.getFullYear();
+            const travelDay = new Date(dateInput);
+            const newTravelDate = travelDay.setFullYear(currentYear);
+            return newTravelDate;
+        }
+    }
+
+    const dt = setTravelDate();
     const geoPlace = primaryData.latitude + ',' + primaryData.longitude;
     const geoPlaceEncoded = encodeUrl(geoPlace);
 
@@ -52,7 +69,8 @@ const buildHistoricApiURLs = (dt)=>{
     }
 
     return urls;
-}
+} 
+//end - global variable (helper function)
 
 //Wrapping functionalities in a init() function to be executed only after DOM is ready
 function init(){
@@ -97,22 +115,18 @@ function init(){
 
                         updateUICurrentWeather(newData, travelDate)});
 
-                } else if(dayCounter(travelDate) > 7 && dayCounter(travelDate) <= 365){ //If the date entered by the user is within one year fetch historical weather for the last 3 years from the Travel Date
+                } else { //If the date entered by the user is in the future
  
                     const apiUrls = buildHistoricApiURLs(travelDate);
                     const url1 = apiUrls.apiURL1;
                     const url2 = apiUrls.apiURL2;
                     const url3 = apiUrls.apiURL3;
 
-                    getHistoricWeatherFromTravelDt(primaryData, url1, url2, url3)
+                    getHistoricWeather(primaryData, url1, url2, url3)
 
                     .then(newObj =>{
                         console.log('primaryData obj preview:', newObj)
                     })
-
-                } else { //If the date entered by the user is within one year fetch historical weather for the last 3 years from Current Date
- 
-                    alert('Your trip is more than 365 days away from now');
                 }
             })
 

--- a/src/client/js/getHistoricWeather.js
+++ b/src/client/js/getHistoricWeather.js
@@ -2,7 +2,7 @@ import { callApiViaServerSide } from "./postRequestToServer"
 
 /* The 3 years of historical weather data are being fetched in 3 separate GET requests due to the
 free API registration plan limitation */
-const getHistoricWeatherFromTravelDt = async (obj, apiUrl1, apiUrl2, apiUrl3)=>{
+const getHistoricWeather = async (obj, apiUrl1, apiUrl2, apiUrl3)=>{
 
     const respOne = await callApiViaServerSide('http://localhost:8081/callAPI', {urlBase:apiUrl1})
     const respTwo = await callApiViaServerSide('http://localhost:8081/callAPI', {urlBase:apiUrl2})
@@ -43,8 +43,9 @@ const getHistoricWeatherFromTravelDt = async (obj, apiUrl1, apiUrl2, apiUrl3)=>{
         return obj;
 
     } catch(err){
-        console.log('Erro tentando fazer uma promisse', err);
+        console.log('Error trying to get historical weather', err);
+        alert("Sorry, we couldn't complete your request. Please try again")
     }
 }
 
-export { getHistoricWeatherFromTravelDt }
+export { getHistoricWeather }


### PR DESCRIPTION
This feat will allow the app to returning the trip's year to the current
year, so it'll fetch the historical weather data of the last 3 years
prior to the current year. This is to prevent the historical weather API
to rejecting the request, since it only allows requests for dates prior
to the current date. E.g., if the trip was more than one year away, and
the app tried to fetch historical data of the last 3 years, it would end
up requesting future weather forecast, which is not allowed when using
historic weather API.