### PR TITLE
fix: Adjust date format in the dayCounter function

### DIFF
--- a/src/client/js/counter.js
+++ b/src/client/js/counter.js
@@ -5,8 +5,9 @@ function dayCounter(userInputDate){
     let d = new Date();
     const months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'];
     const month = months[d.getMonth()];
+    const day = `0${d.getDate()}`.slice(-2);
 
-    const today = `${d.getFullYear()}-${month}-${d.getDate()}`;
+    const today = `${d.getFullYear()}-${month}-${day}`;
     const travelDate = userInputDate;
 
     let differenceInMs = new Date(travelDate) - new Date(today);


### PR DESCRIPTION
This change is intended to show the countdown of days in integers
instead of decimals, thus avoiding results like "NaN" in IOS operating
systems.